### PR TITLE
二进制图读入

### DIFF
--- a/gpu/gpu_graph.cu
+++ b/gpu/gpu_graph.cu
@@ -8,6 +8,7 @@
 #include <common.h>
 
 #include <cassert>
+#include <cstring>
 #include <cstdint>
 #include <string>
 #include <algorithm>
@@ -240,7 +241,7 @@ __device__ uint32_t do_intersection(uint32_t* out, const uint32_t* a, const uint
     if (lid == 0)
         out_size = 0;
 
-    uint32_t v, num_done = 0;
+    uint32_t num_done = 0;
     while (num_done < na) {
         bool found = 0;
         uint32_t u = 0;
@@ -788,27 +789,44 @@ int main(int argc,char *argv[]) {
     Graph *g;
     DataLoader D;
 
-    if (argc < 3) {
-        printf("Example Usage: %s Patents ~zms/patents_input\n", argv[0]);
+    if (argc < 2) {
+        printf("Usage: %s dataset_name graph_file [binary/text]\n", argv[0]);
+        printf("Example: %s Patents ~hzx/data/patents_bin binary\n", argv[0]);
+        printf("Example: %s Patents ~zms/patents_input\n", argv[0]);
+
+        printf("\nExperimental usage: %s [graph_file.g]\n", argv[0]);
+        printf("Example: %s ~hzx/data/patents.g\n", argv[0]);
         return 0;
     }
 
-    const std::string type = argv[1];
-    const std::string path = argv[2];
+    bool binary_input = false;
+    if (argc >= 4)
+        binary_input = (strcmp(argv[3], "binary") == 0);
 
     DataType my_type;
+    if (argc >= 3) {
+        GetDataType(my_type, argv[1]);
 
-    GetDataType(my_type, type);
-
-    if(my_type == DataType::Invalid) {
-        printf("Dataset not found!\n");
-        return 0;
+        if (my_type == DataType::Invalid) {
+            printf("Dataset not found!\n");
+            return 0;
+        }
     }
 
     using std::chrono::system_clock;
     auto t1 = system_clock::now();
 
-    assert(D.load_data(g, my_type, path.c_str())); 
+    bool ok;
+    if (argc >= 3) {
+        // 注：load_data的第四个参数用于指定是否读取二进制文件输入，默认为false
+        ok = D.load_data(g, my_type, argv[2], binary_input);
+    } else {
+        ok = D.fast_load(g, argv[1]);
+    }
+    if (!ok) {
+        printf("data load failure :-(\n");
+        return 0;
+    }
 
     auto t2 = system_clock::now();
     auto load_time = std::chrono::duration_cast<std::chrono::microseconds>(t2 - t1);
@@ -829,7 +847,11 @@ int main(int argc,char *argv[]) {
     bool use_in_exclusion_optimize = true;
     Schedule schedule(p, is_pattern_valid, 1, 1, use_in_exclusion_optimize, g->v_cnt, g->e_cnt, g->tri_cnt);
     //Schedule schedule(p, is_pattern_valid, 0, 1, use_in_exclusion_optimize, g->v_cnt, g->e_cnt, g->tri_cnt); // use the best schedule
-    assert(is_pattern_valid);
+
+    if (!is_pattern_valid) {
+        printf("pattern is invalid!\n");
+        return 0;
+    }
 
     pattern_matching_init(g, schedule);
 

--- a/include/dataloader.h
+++ b/include/dataloader.h
@@ -27,7 +27,8 @@ constexpr long long Twitter_tri_cnt = 34824916864LL;
 class DataLoader {
 public:
 
-    bool load_data(Graph* &g, DataType type, const char* path, int oriented_type = 0);
+    bool load_data(Graph* &g, DataType type, const char* path, bool binary_input = false, int oriented_type = 0);
+        // binary_input: binary graph input if true, otherwise text
         // pattern_diameter means max distance between two vertex in graph
         // oriented_type is used to reorder dataset
         // oriented_type == 0 do nothing
@@ -35,14 +36,16 @@ public:
         //               == 2 low degree first
     bool load_data(Graph* &g, int clique_size);
 
+    bool fast_load(Graph* &g, const char* path);
+
 private:
     static bool cmp_pair(std::pair<int,int>a, std::pair<int,int>b);
     static bool cmp_degree_gt(std::pair<int,int> a,std::pair<int,int> b);
     static bool cmp_degree_lt(std::pair<int,int> a,std::pair<int,int> b);
 
     long long comb(int n,int k);
-    bool general_load_data(Graph* &g, DataType type, const char* path, int oriented_type = 0);
+    bool general_load_data(Graph* &g, DataType type, const char* path, bool binary_input, int oriented_type = 0);
     bool twitter_load_data(Graph* &g, DataType type, const char* path, int oriented_type = 0);
 
-    std::unordered_map<int,int> id;
+    std::unordered_map<uint32_t, uint32_t> id;
 };

--- a/scripts/analyze.py
+++ b/scripts/analyze.py
@@ -1,55 +1,75 @@
-with open('timing.txt', 'r') as f:
-    lines = f.readlines()
-
-records = []
-for line in lines:
-    if line.startswith('@'):
-        records.append(line[1:].strip().split(','))
-
-warp_ids = set([int(r[0]) for r in records])
-print("number of warps: %d" % len(warp_ids))
-'''
-time_points = []
-for r in records:
-    time_points.append(int(r[1]))
-    time_points.append(int(r[2]))
-time_points = sorted(time_points)
-
-unique_time_points = [time_points[0]]
-for i in range(1, len(time_points)):
-    if time_points[i] != time_points[i - 1]:
-        unique_time_points.append(time_points[i])
-
-max_timestamp = unique_time_points[-1]
-nr_intervals = 10000
-interval_len = (max_timestamp + nr_intervals - 1) // nr_intervals
-active_warps_count = [0.0] * nr_intervals
-for r in records:
-    t1, t2 = int(r[1]), int(r[2])
-
-    left  = t1 // interval_len
-    right = (t2 + interval_len - 1) // interval_len
-    for i in range(left, right):
-        begin = interval_len * i
-        end = begin + interval_len
-        active_warps_count[i] += (min(end, t2) - max(begin, t1)) / interval_len
-'''
-total_time_costs = {}
-num_tasks = {}
-time_costs = []
-for r in records:
-    warp_id, t1, t2 = int(r[0]), int(r[1]), int(r[2])
-    time_costs.append(t2 - t1)
-    #
-    tot = total_time_costs.get(warp_id, 0)
-    tot += t2 - t1
-    total_time_costs[warp_id] = tot
-    #
-    num_tasks[warp_id] = num_tasks.get(warp_id, 0) + 1
-
 import json
-with open('time_costs.json', 'w') as f:
-    json.dump({'task_time': time_costs, 'total_time': total_time_costs, 'num_tasks': num_tasks}, f)
 
-from IPython import embed
-#embed()
+if 0: # 输入格式：@warp_id,time_begin,time_end
+    with open('timing.txt', 'r') as f:
+        lines = f.readlines()
+
+    records = []
+    for line in lines:
+        if line.startswith('@'):
+            records.append(line[1:].strip().split(','))
+
+    warp_ids = set([int(r[0]) for r in records])
+    print("number of warps: %d" % len(warp_ids))
+    '''
+    time_points = []
+    for r in records:
+        time_points.append(int(r[1]))
+        time_points.append(int(r[2]))
+    time_points = sorted(time_points)
+
+    unique_time_points = [time_points[0]]
+    for i in range(1, len(time_points)):
+        if time_points[i] != time_points[i - 1]:
+            unique_time_points.append(time_points[i])
+
+    max_timestamp = unique_time_points[-1]
+    nr_intervals = 10000
+    interval_len = (max_timestamp + nr_intervals - 1) // nr_intervals
+    active_warps_count = [0.0] * nr_intervals
+    for r in records:
+        t1, t2 = int(r[1]), int(r[2])
+
+        left  = t1 // interval_len
+        right = (t2 + interval_len - 1) // interval_len
+        for i in range(left, right):
+            begin = interval_len * i
+            end = begin + interval_len
+            active_warps_count[i] += (min(end, t2) - max(begin, t1)) / interval_len
+    '''
+    total_time_costs = {}
+    num_tasks = {}
+    time_costs = []
+    for r in records:
+        warp_id, t1, t2 = int(r[0]), int(r[1]), int(r[2])
+        time_costs.append(t2 - t1)
+        #
+        tot = total_time_costs.get(warp_id, 0)
+        tot += t2 - t1
+        total_time_costs[warp_id] = tot
+        #
+        num_tasks[warp_id] = num_tasks.get(warp_id, 0) + 1
+
+    with open('time_costs.json', 'w') as f:
+        json.dump({'task_time': time_costs, 'total_time': total_time_costs, 'num_tasks': num_tasks}, f)
+
+if __name__ == '__main__':
+    # 输入格式：@smid:end_time
+    with open('timing.txt', 'r') as f:
+        lines = f.readlines()
+
+    data = []
+    timestamps = []
+    for line in lines:
+        if not line.startswith('@'):
+            continue
+        r = line[1:].strip().split(':')
+        data.append(tuple(map(int, r)))
+        timestamps.append(int(r[1]))
+
+    min_time = min(timestamps)
+    timestamps = [t - min_time for t in timestamps]
+    print(timestamps)
+    
+    from IPython import embed
+    #embed()


### PR DESCRIPTION
主要修改了dataloader相关部分，兼容原来的读入
可以像原来bin/gpu_graph MiCo ~zms/mico_input

二进制图文件放在~hzx/data/下面，注意后缀为.g（以_bin结尾的二进制数据结构与原文本的相同，可以不管
使用时直接给出文件名即可，如bin/gpu_graph ~hzx/data/patents.g即可，无需指定数据集名称